### PR TITLE
fix raspberrypi-2 build: meson configure error

### DIFF
--- a/.github/workflows/build-gg.yml
+++ b/.github/workflows/build-gg.yml
@@ -50,6 +50,7 @@ jobs:
            chown yoctouser /sstate-cache
            chown yoctouser /downloads
            chown -R yoctouser .
+           sysctl vm.mmap_min_addr=65536
            env
            sudo -u yoctouser bash -c '\
             whoami && \


### PR DESCRIPTION
This is necessary for building arm32 in CodeBuild
sysctl vm.mmap_min_addr=65536

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
