### PR TITLE
Rename Nucleus-Lite config to NucleusLite

### DIFF
--- a/meta-aws-demos/recipes-iot/aws-iot-greengrass/greengrass-config-init/greengrass-config-init.sh
+++ b/meta-aws-demos/recipes-iot/aws-iot-greengrass/greengrass-config-init/greengrass-config-init.sh
@@ -13,7 +13,7 @@ if [ -e /dev/mmcblk0p1 ]; then
             echo "ggconfigd found - gg-lite"
             config_file="/etc/greengrass/config.yaml"
             unzip -jo $config_zip -d /etc/greengrass/
-            sed -i -e s:{{config_dir}}:\/etc\/greengrass:g -e s:{{nucleus_component}}:aws.greengrass.Nucleus-Lite:g $config_file
+            sed -i -e s:{{config_dir}}:\/etc\/greengrass:g -e s:{{nucleus_component}}:aws.greengrass.NucleusLite:g $config_file
         elif [ -d "/greengrass/v2/" ]; then
             echo "/greengrass/v2/ found - gg-classic"
             config_file="/greengrass/v2/config/config.yaml"

--- a/meta-aws-demos/recipes-iot/aws-iot-greengrass/greengrass-lite/greengrass-lite.yaml
+++ b/meta-aws-demos/recipes-iot/aws-iot-greengrass/greengrass-lite/greengrass-lite.yaml
@@ -2,7 +2,7 @@
 system:
   rootPath: "@GG_WORKING_DIR@"
 services:
-  aws.greengrass.Nucleus-Lite:
+  aws.greengrass.NucleusLite:
     componentType: "NUCLEUS"
     configuration:
       runWithDefault:


### PR DESCRIPTION
*Issue #, if available:*
Created to support aws-greengrass/aws-greengrass-lite#707
*Description of changes:*
Rename system/aws.greengrass.Nucleus-Lite to system/aws.greengrass.NucleusLite in config keys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
