### PR TITLE
conf/devices/raspberrypi-64/config.conf: Fix RPi 5 hw rev. 1.1 support

### DIFF
--- a/meta-aws-demos/conf/devices/raspberrypi-64/config.conf
+++ b/meta-aws-demos/conf/devices/raspberrypi-64/config.conf
@@ -10,3 +10,6 @@ ENABLE_UART = "1"
 
 # https://meta-raspberrypi.readthedocs.io/en/latest/ipcompliance.html
 LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"
+
+# necessary as long as this PR is not merged: https://github.com/agherzan/meta-raspberrypi/pull/1460
+RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/bcm2712d0.dtbo"


### PR DESCRIPTION
Details here: https://github.com/agherzan/meta-raspberrypi/pull/1460

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
