### PR TITLE
aws-iot-greengrass-lite-walltablet-demo-image: config.conf

### DIFF
--- a/meta-aws-demos/recipes-core/images/aws-iot-greengrass-lite-walltablet-demo-image/config.conf
+++ b/meta-aws-demos/recipes-core/images/aws-iot-greengrass-lite-walltablet-demo-image/config.conf
@@ -2,6 +2,7 @@ DISTRO = "poky-altcfg"
 
 QB_MEM = "-m 2048"
 BOOT_SPACE = "69152"
+DEFAULT_ROOTFS_PARTITION_SIZE = "2097152"
 
 # we are read only, no addition space necessary
 IMAGE_OVERHEAD_FACTOR = "1.1"


### PR DESCRIPTION
DEFAULT_ROOTFS_PARTITION_SIZE = "2097152"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
