### PR TITLE
remove git meta-lts-mixins for rust

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,10 +106,6 @@
 	path = layers/sw/meta-clang
 	url = https://github.com/kraj/meta-clang.git
 	branch = scarthgap
-[submodule "layers/sw/meta-lts-mixins"]
-	path = layers/sw/meta-lts-mixins
-	url = https://git.yoctoproject.org/meta-lts-mixins
-	branch = scarthgap/rust
 [submodule "layers/sw/meta-browser"]
 	path = layers/sw/meta-browser
 	url = https://github.com/OSSystems/meta-browser.git


### PR DESCRIPTION
not necessary

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
